### PR TITLE
feat(lazy-replicated): add lazy-pull replicated cache adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       NEBULEX_PATH: nebulex
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
@@ -52,34 +52,36 @@ jobs:
           elixir-version: '${{ matrix.elixir }}'
 
       - name: Cache deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps
           key: >-
-            ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{
+            ${{ matrix.elixir }}-${{ matrix.otp }}-${{ runner.os }}-mix-${{
             hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
+            ${{ matrix.elixir }}-${{ matrix.otp }}-${{ runner.os }}-mix-
 
       - name: Cache _build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: >-
-            ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build-${{
+            ${{ matrix.elixir }}-${{ matrix.otp }}-${{ runner.os }}-build-${{
             hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build-
+            ${{ matrix.elixir }}-${{ matrix.otp }}-${{ runner.os }}-build-
 
       - name: Install Nebulex
         run: mix nbx.setup
 
-      - name: Install Dependencies
+      - name: Install Hex and Rebar
         run: |
           mix local.hex --force
           mix local.rebar --force
-          mix deps.get
+
+      - name: Install Dependencies
+        run: mix deps.get
         if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}
 
       - name: Compile deps
@@ -98,10 +100,6 @@ jobs:
           mix format --check-formatted
           mix credo --strict
         if: ${{ matrix.lint }}
-
-      - name: Run sobelow
-        run: mix sobelow --skip --exit Low
-        if: ${{ matrix.sobelow }}
 
       - name: Run tests
         run: |
@@ -122,12 +120,20 @@ jobs:
           flags: unittests-elixir-${{ matrix.elixir }}-otp-${{ matrix.otp }}
         if: ${{ matrix.coverage }}
 
+      - name: Run sobelow
+        run: mix sobelow --skip --exit Low
+        if: ${{ matrix.sobelow }}
+
       - name: Restore PLT Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: plt-cache
         with:
           path: priv/plts
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plt-v1
+          key: >-
+            plt-${{ matrix.elixir }}-${{ matrix.otp }}-${{
+            hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            plt-${{ matrix.elixir }}-${{ matrix.otp }}-
         if: ${{ matrix.dialyzer }}
 
       - name: Create PLTs
@@ -138,4 +144,4 @@ jobs:
 
       - name: Run dialyzer
         run: mix dialyzer --format github
-        if: ${{ matrix.dialyzer && steps.plt-cache.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.dialyzer }}

--- a/lib/nebulex/adapters/coherent.ex
+++ b/lib/nebulex/adapters/coherent.ex
@@ -314,35 +314,40 @@ defmodule Nebulex.Adapters.Coherent do
 
   @impl true
   def put(adapter_meta, key, value, on_write, ttl, keep_ttl?, opts) do
-    primary_opts = [ttl: ttl, keep_ttl: keep_ttl?] ++ opts
+    primary_opts = Keyword.merge(opts, ttl: ttl, keep_ttl: keep_ttl?)
 
-    case on_write do
-      :put ->
-        with :ok <- with_dynamic_cache(adapter_meta, :put, [key, value, primary_opts]) do
-          {:ok, true}
-        end
+    do_put(on_write, adapter_meta, key, value, primary_opts)
+  end
 
-      :put_new ->
-        with_dynamic_cache(adapter_meta, :put_new, [key, value, primary_opts])
-
-      :replace ->
-        with_dynamic_cache(adapter_meta, :replace, [key, value, primary_opts])
+  defp do_put(:put, adapter_meta, key, value, primary_opts) do
+    with :ok <- with_dynamic_cache(adapter_meta, :put, [key, value, primary_opts]) do
+      {:ok, true}
     end
+  end
+
+  defp do_put(:put_new, adapter_meta, key, value, primary_opts) do
+    with_dynamic_cache(adapter_meta, :put_new, [key, value, primary_opts])
+  end
+
+  defp do_put(:replace, adapter_meta, key, value, primary_opts) do
+    with_dynamic_cache(adapter_meta, :replace, [key, value, primary_opts])
   end
 
   @impl true
   def put_all(adapter_meta, entries, on_write, ttl, opts) do
-    primary_opts = [ttl: ttl] ++ opts
+    primary_opts = Keyword.put(opts, :ttl, ttl)
 
-    case on_write do
-      :put ->
-        with :ok <- with_dynamic_cache(adapter_meta, :put_all, [entries, primary_opts]) do
-          {:ok, true}
-        end
+    do_put_all(on_write, adapter_meta, entries, primary_opts)
+  end
 
-      :put_new ->
-        with_dynamic_cache(adapter_meta, :put_new_all, [entries, primary_opts])
+  defp do_put_all(:put, adapter_meta, entries, primary_opts) do
+    with :ok <- with_dynamic_cache(adapter_meta, :put_all, [entries, primary_opts]) do
+      {:ok, true}
     end
+  end
+
+  defp do_put_all(:put_new, adapter_meta, entries, primary_opts) do
+    with_dynamic_cache(adapter_meta, :put_new_all, [entries, primary_opts])
   end
 
   @impl true

--- a/lib/nebulex/adapters/coherent/options.ex
+++ b/lib/nebulex/adapters/coherent/options.ex
@@ -136,6 +136,24 @@ defmodule Nebulex.Adapters.Coherent.Options do
   # Start options schema
   @start_opts_schema NimbleOptions.new!(start_opts)
 
+  # Shared compile options
+  @shared_compile_opts compile_opts
+
+  # Shared start options
+  @shared_start_opts start_opts
+
+  ## Shared Options API
+
+  # coveralls-ignore-start
+
+  @spec shared_compile_opts() :: keyword()
+  def shared_compile_opts, do: @shared_compile_opts
+
+  @spec shared_start_opts() :: keyword()
+  def shared_start_opts, do: @shared_start_opts
+
+  # coveralls-ignore-stop
+
   ## Docs API
 
   # coveralls-ignore-start

--- a/lib/nebulex/adapters/lazy_replicated.ex
+++ b/lib/nebulex/adapters/lazy_replicated.ex
@@ -1,0 +1,621 @@
+defmodule Nebulex.Adapters.LazyReplicated do
+  @moduledoc """
+  Adapter module for the lazy-replicated cache topology using lazy-pull replication.
+
+  ## Features
+
+    * Replicated cache topology with lazy-pull replication.
+    * Zero-latency local reads for cached data.
+    * Automatic cache invalidation via `Nebulex.Streams`.
+    * On-demand data replication: cache misses pull from peer nodes
+      transparently.
+    * Trivial node joins: new nodes start with an empty cache and fill
+      lazily as reads come in.
+    * Configurable primary storage adapter.
+
+  ## Lazy-Replicated Cache Topology
+
+  The lazy-replicated adapter provides a "local cache with distributed invalidation
+  and lazy-pull replication" pattern. Each node maintains its own local cache.
+  Writes trigger invalidation events across the cluster, and cache misses
+  transparently pull data from peer nodes.
+
+  Key characteristics:
+
+    * _**Local Storage**_: Each node has a local cache. All read operations
+      are served directly from the local cache when the data is available,
+      with no network overhead.
+
+    * _**Distributed Invalidation**_: When a cache entry is modified (inserted,
+      updated, or deleted), an event is broadcast to all nodes in the cluster.
+      Other nodes invalidate (delete) that entry from their local caches.
+
+    * _**Lazy-Pull Replication**_: On a cache miss (after invalidation or on
+      a new node), the adapter transparently pulls the data from a peer node
+      that has it, caches it locally, and returns it. Over time, frequently
+      accessed data naturally replicates across all nodes.
+
+    * _**Eventual Consistency**_: After invalidation, the next read on other
+      nodes triggers a pull from a peer, ensuring the latest value propagates
+      across the cluster.
+
+    * _**Write-Invalidate Protocol**_: Only invalidation events are broadcast
+      on writes, not the actual values. Data is only transferred when needed
+      (on cache misses), minimizing network overhead.
+
+  ## How It Works
+
+  ```
+  Node A                          Node B                          Node C
+  ┌──────────────┐               ┌──────────────┐               ┌──────────────┐
+  │ Local Cache  │               │ Local Cache  │               │ Local Cache  │
+  └──────┬───────┘               └──────┬───────┘               └──────┬───────┘
+         │                              │                              │
+         └──────────────┬───────────────┴──────────────┬───────────────┘
+                        │                              │
+                 ┌──────┴──────┐                ┌──────┴──────┐
+                 │   Streams   │◄──────────────►│ Invalidator │
+                 │  (PubSub)   │                │  (Workers)  │
+                 └─────────────┘                └─────────────┘
+  ```
+
+  ### Write flow
+
+    1. Node A modifies a cache entry (e.g., `Cache.put("key", value)`).
+    2. The local cache stores the value and emits a cache event.
+    3. `Nebulex.Streams` broadcasts the event via Phoenix.PubSub.
+    4. The `Nebulex.Streams.Invalidator` on Nodes B and C receives the event.
+    5. The Invalidator deletes "key" from the local caches on B and C.
+
+  ### Read flow
+
+    1. Node B reads "key" from its local cache.
+    2. If hit → return immediately (zero latency).
+    3. If miss → pull from a peer node via RPC, cache locally, and return.
+    4. If no peer has it → return cache miss (application handles via
+       cache-aside pattern).
+
+  ### Node join
+
+    1. New node joins the `:pg` group, starts receiving invalidation events.
+    2. Cache starts empty — data fills in lazily as reads come in.
+    3. No bulk sync, no write blocking, no special join protocol.
+
+  ## When to Use
+
+  The lazy-replicated adapter is ideal for:
+
+    * _**Read-Heavy Workloads**_: Maximum read performance since all reads
+      are served locally after the first pull.
+    * _**Clusters Where Most Nodes Read the Same Data**_: Lazy replication
+      naturally distributes hot data to all nodes that need it.
+    * _**Scenarios Where Node Joins Must Not Block Writes**_: New nodes
+      start empty and fill on demand.
+    * _**When Eventual Consistency Is Acceptable**_: It's a cache — stale
+      data expires or gets invalidated.
+
+  ## Comparison with Other Adapters
+
+  | Aspect | LazyReplicated | Coherent | Partitioned |
+  |--------|-----------|----------|-------------|
+  | Read (hit) | Local (zero latency) | Local (zero latency) | RPC to owner node |
+  | Read (miss) | Pull from peer, then local | Miss → app fetches from SoR | RPC to owner node |
+  | Write | Local + invalidation broadcast | Local + invalidation broadcast | RPC to owner node |
+  | Node join | Empty, fills on demand | Empty, fills on demand | Full ring sync |
+  | Data location | Replicated on demand | Independent per node | Sharded across nodes |
+  | Consistency | Eventual | Eventual | Strong (single owner) |
+  | Network overhead | Low (invalidation + pull on miss) | Low (only invalidations) | Medium (data transfer) |
+
+  ## Primary Storage Adapter
+
+  This adapter depends on a local cache adapter (primary storage), adding a
+  distributed invalidation layer with lazy-pull replication on top of it. You
+  don't need to manually define the primary storage cache; the adapter
+  initializes it automatically as part of the supervision tree.
+
+  The `:primary_storage_adapter` option (defaults to `Nebulex.Adapters.Local`)
+  configures which adapter to use for the local storage. Options for the
+  primary adapter can be specified via the `:primary` configuration option.
+
+  ## Usage
+
+  The cache expects the `:otp_app` and `:adapter` as options when used.
+  The `:otp_app` should point to an OTP application with the cache
+  configuration. Optionally, you can configure the desired primary storage
+  adapter with the option `:primary_storage_adapter` (defaults to
+  `Nebulex.Adapters.Local`). See the compile time options for more information:
+
+  #{Nebulex.Adapters.LazyReplicated.Options.compile_options_docs()}
+
+  For example:
+
+      defmodule MyApp.ReplicatedCache do
+        use Nebulex.Cache,
+          otp_app: :my_app,
+          adapter: Nebulex.Adapters.LazyReplicated
+      end
+
+  Providing a custom `:primary_storage_adapter`:
+
+      defmodule MyApp.ReplicatedCache do
+        use Nebulex.Cache,
+          otp_app: :my_app,
+          adapter: Nebulex.Adapters.LazyReplicated,
+          adapter_opts: [primary_storage_adapter: Nebulex.Adapters.Local]
+      end
+
+  Configuration in `config/config.exs`:
+
+      config :my_app, MyApp.ReplicatedCache,
+        primary: [
+          gc_interval: :timer.hours(12),
+          max_size: 1_000_000
+        ],
+        stream_opts: [
+          partitions: System.schedulers_online()
+        ]
+
+  Add the cache to your supervision tree:
+
+      def start(_type, _args) do
+        children = [
+          {MyApp.ReplicatedCache, []},
+          ...
+        ]
+
+        opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
+
+  See `Nebulex.Cache` for more information.
+
+  ## Configuration Options
+
+  This adapter supports the following configuration options:
+
+  #{Nebulex.Adapters.LazyReplicated.Options.start_options_docs()}
+
+  ## Shared runtime options
+
+  When using the lazy-replicated adapter, all of the cache functions outlined in
+  `Nebulex.Cache` accept the following options:
+
+  #{Nebulex.Adapters.LazyReplicated.Options.common_runtime_options_docs()}
+
+  ## Telemetry Events
+
+  Since the lazy-replicated adapter depends on the configured primary storage cache
+  (which uses a local cache adapter), this one will also emit Telemetry events.
+  Additionally, `Nebulex.Streams` and `Nebulex.Streams.Invalidator` emit their
+  own telemetry events for monitoring the invalidation process.
+
+  See the [Telemetry guide](https://hexdocs.pm/nebulex/telemetry.html) and
+  `Nebulex.Streams` documentation for more information.
+
+  ## Extended API
+
+  This adapter provides some additional convenience functions to the
+  `Nebulex.Cache` API.
+
+  Retrieving the primary storage or local cache module:
+
+      MyCache.__primary__()
+
+  Retrieving the cluster nodes associated with the given cache `name`:
+
+      MyCache.nodes()
+
+  Joining the cache to the cluster:
+
+      MyCache.join_cluster()
+
+  Leaving the cluster (removes the cache from the cluster):
+
+      MyCache.leave_cluster()
+
+  ## Caveats
+
+    * _**Eventual Consistency Window**_: There is a latency between when a write
+      occurs on one node and when the invalidation is processed on other nodes.
+      During this window, other nodes may serve stale data. The duration depends
+      on network latency and PubSub message delivery. For most use cases this is
+      negligible, but time-sensitive applications should account for this.
+
+    * _**First Read After Invalidation**_: The first read on a remote node after
+      invalidation incurs a network hop to pull the data from a peer. Subsequent
+      reads are local. This trade-off enables trivial node joins and eliminates
+      write-time replication overhead.
+
+    * _**Memory Usage**_: Over time, frequently accessed data replicates to all
+      nodes that read it. Memory usage depends on each node's access patterns
+      and the primary adapter's configuration (e.g., `:max_size`, `:gc_interval`).
+
+    * _**Queryable Operations**_: Only `get_all(in: [k1, k2, ...])` triggers
+      lazy-pull replication for missing keys. General queries
+      (`get_all(query: nil)`, `count_all`, `delete_all`, `stream`) operate on
+      the local cache only — merging arbitrary query results from all peers is
+      not practical.
+
+  """
+
+  # Provide Cache Implementation
+  @behaviour Nebulex.Adapter
+  @behaviour Nebulex.Adapter.KV
+  @behaviour Nebulex.Adapter.Queryable
+  @behaviour Nebulex.Adapter.Transaction
+  @behaviour Nebulex.Adapter.Info
+
+  # Inherit default observable implementation
+  use Nebulex.Adapter.Observable
+
+  import Nebulex.Utils
+
+  alias __MODULE__.Options
+  alias Nebulex.Adapter
+  alias Nebulex.Distributed.{Cluster, RPC}
+
+  ## Nebulex.Adapter
+
+  @impl true
+  defmacro __before_compile__(env) do
+    otp_app = Module.get_attribute(env.module, :otp_app)
+    opts = Module.get_attribute(env.module, :opts)
+    adapter_opts = Keyword.fetch!(opts, :adapter_opts)
+
+    adapter_opts = Options.validate_compile_opts!(adapter_opts)
+    primary = Keyword.fetch!(adapter_opts, :primary_storage_adapter)
+
+    quote do
+      defmodule Primary do
+        @moduledoc """
+        This is the cache for the primary storage.
+        """
+        use Nebulex.Cache,
+          otp_app: unquote(otp_app),
+          adapter: unquote(primary)
+
+        use Nebulex.Streams
+      end
+
+      @doc """
+      A convenience function for getting the primary storage cache.
+      """
+      def __primary__, do: Primary
+
+      @doc """
+      A convenience function for getting the cluster nodes.
+      """
+      def nodes(name \\ get_dynamic_cache()) do
+        name
+        |> get_pg_group()
+        |> Cluster.pg_nodes()
+      end
+
+      @doc """
+      A convenience function for joining the cache to the cluster.
+      """
+      def join_cluster(name \\ get_dynamic_cache()) do
+        name
+        |> get_pg_group()
+        |> Cluster.join()
+      end
+
+      @doc """
+      A convenience function for removing the cache from the cluster.
+      """
+      def leave_cluster(name \\ get_dynamic_cache()) do
+        name
+        |> get_pg_group()
+        |> Cluster.leave()
+      end
+
+      @doc """
+      A convenience function for getting the PG group name.
+      """
+      def get_pg_group(name) do
+        name
+        |> Adapter.lookup_meta()
+        |> Map.fetch!(:pg_group)
+      end
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    # Common options
+    {telemetry_prefix, opts} = Keyword.pop!(opts, :telemetry_prefix)
+    {telemetry, opts} = Keyword.pop!(opts, :telemetry)
+    {cache, opts} = Keyword.pop!(opts, :cache)
+
+    # Validate options
+    opts = Options.validate_start_opts!(opts)
+
+    # Get the cache name (required)
+    name = opts[:name] || cache
+
+    # Primary cache options
+    primary_opts =
+      Keyword.merge(
+        [telemetry_prefix: telemetry_prefix ++ [:primary], telemetry: telemetry],
+        Keyword.fetch!(opts, :primary)
+      )
+
+    # Maybe put a name to primary storage
+    primary_opts =
+      if opts[:name],
+        do: [name: camelize_and_concat([name, Primary])] ++ primary_opts,
+        else: primary_opts
+
+    # Stream options
+    stream_opts = Keyword.fetch!(opts, :stream_opts)
+
+    # PG group name for cluster membership
+    pg_group = camelize_and_concat([name, PG])
+
+    # Prepare metadata
+    adapter_meta = %{
+      telemetry_prefix: telemetry_prefix,
+      telemetry: telemetry,
+      name: name,
+      primary_name: primary_opts[:name],
+      pg_group: pg_group
+    }
+
+    # Prepare child spec
+    child_spec =
+      Supervisor.child_spec(
+        {Nebulex.Adapters.LazyReplicated.Supervisor,
+         {cache, adapter_meta, primary_opts, stream_opts}},
+        id: {__MODULE__, name}
+      )
+
+    {:ok, child_spec, adapter_meta}
+  end
+
+  ## Nebulex.Adapter.KV — Read callbacks with pull-from-peers
+
+  @impl true
+  def fetch(adapter_meta, key, opts) do
+    with {:error, %Nebulex.KeyError{}} = e <- with_dynamic_cache(adapter_meta, :fetch, [key, opts]),
+         {:ok, {value, _ttl}} <- pull_and_cache(adapter_meta, key, opts, e) do
+      {:ok, value}
+    end
+  end
+
+  @impl true
+  def take(adapter_meta, key, opts) do
+    with {:error, %Nebulex.KeyError{}} = e <- with_dynamic_cache(adapter_meta, :take, [key, opts]),
+         {:ok, {value, _ttl}} <- rpc_first_peer(adapter_meta, key, opts, e) do
+      {:ok, value}
+    end
+  end
+
+  @impl true
+  def has_key?(adapter_meta, key, opts) do
+    with {:ok, false} <- with_dynamic_cache(adapter_meta, :has_key?, [key, opts]) do
+      init_acc = wrap_error Nebulex.KeyError, key: key
+
+      case pull_and_cache(adapter_meta, key, opts, init_acc) do
+        {:ok, _} -> {:ok, true}
+        {:error, %Nebulex.KeyError{}} -> {:ok, false}
+      end
+    end
+  end
+
+  @impl true
+  def ttl(adapter_meta, key, opts) do
+    with {:error, %Nebulex.KeyError{}} = e <- with_dynamic_cache(adapter_meta, :ttl, [key, opts]),
+         {:ok, {_value, ttl}} <- pull_and_cache(adapter_meta, key, opts, e) do
+      {:ok, ttl}
+    end
+  end
+
+  ## Nebulex.Adapter.KV — Write callbacks (delegate to local primary + invalidation)
+
+  @impl true
+  def put(adapter_meta, key, value, on_write, ttl, keep_ttl?, opts) do
+    primary_opts = Keyword.merge(opts, ttl: ttl, keep_ttl: keep_ttl?)
+
+    do_put(on_write, adapter_meta, key, value, primary_opts)
+  end
+
+  defp do_put(:put, adapter_meta, key, value, primary_opts) do
+    with :ok <- with_dynamic_cache(adapter_meta, :put, [key, value, primary_opts]) do
+      {:ok, true}
+    end
+  end
+
+  defp do_put(:put_new, adapter_meta, key, value, primary_opts) do
+    with_dynamic_cache(adapter_meta, :put_new, [key, value, primary_opts])
+  end
+
+  defp do_put(:replace, adapter_meta, key, value, primary_opts) do
+    with_dynamic_cache(adapter_meta, :replace, [key, value, primary_opts])
+  end
+
+  @impl true
+  def put_all(adapter_meta, entries, on_write, ttl, opts) do
+    primary_opts = Keyword.put(opts, :ttl, ttl)
+
+    do_put_all(on_write, adapter_meta, entries, primary_opts)
+  end
+
+  defp do_put_all(:put, adapter_meta, entries, primary_opts) do
+    with :ok <- with_dynamic_cache(adapter_meta, :put_all, [entries, primary_opts]) do
+      {:ok, true}
+    end
+  end
+
+  defp do_put_all(:put_new, adapter_meta, entries, primary_opts) do
+    with_dynamic_cache(adapter_meta, :put_new_all, [entries, primary_opts])
+  end
+
+  @impl true
+  def delete(adapter_meta, key, opts) do
+    with_dynamic_cache(adapter_meta, :delete, [key, opts])
+  end
+
+  @impl true
+  def expire(adapter_meta, key, ttl, opts) do
+    with_dynamic_cache(adapter_meta, :expire, [key, ttl, opts])
+  end
+
+  @impl true
+  def touch(adapter_meta, key, opts) do
+    with_dynamic_cache(adapter_meta, :touch, [key, opts])
+  end
+
+  @impl true
+  def update_counter(adapter_meta, key, amount, default, ttl, opts) do
+    with_dynamic_cache(adapter_meta, :incr, [key, amount, [ttl: ttl, default: default] ++ opts])
+  end
+
+  ## Nebulex.Adapter.Queryable
+
+  @impl true
+  def execute(adapter_meta, query, opts)
+
+  def execute(adapter_meta, %{op: :get_all, query: {:in, keys}, select: select}, opts)
+      when is_list(keys) do
+    # Always query locally with {:key, :value} to know which keys are present
+    kv_query = [in: keys, select: {:key, :value}]
+
+    with {:ok, local_kv} <- with_dynamic_cache(adapter_meta, :get_all, [kv_query, opts]) do
+      local_keys = Enum.map(local_kv, &elem(&1, 0))
+      missing_keys = keys -- local_keys
+
+      pulled_kv = pull_missing_keys(adapter_meta, missing_keys, opts)
+      all_kv = local_kv ++ pulled_kv
+
+      {:ok, select_from_kv(all_kv, select)}
+    end
+  end
+
+  def execute(adapter_meta, %{op: op} = query, opts) do
+    query = build_query(query)
+
+    with_dynamic_cache(adapter_meta, op, [query, opts])
+  end
+
+  @impl true
+  def stream(adapter_meta, query, opts) do
+    query = build_query(query)
+
+    with_dynamic_cache(adapter_meta, :stream, [query, opts])
+  end
+
+  ## Nebulex.Adapter.Transaction
+
+  @impl true
+  def transaction(adapter_meta, fun, opts) do
+    with_dynamic_cache(adapter_meta, :transaction, [fun, opts])
+  end
+
+  @impl true
+  def in_transaction?(adapter_meta, opts) do
+    with_dynamic_cache(adapter_meta, :in_transaction?, [opts])
+  end
+
+  ## Nebulex.Adapter.Info
+
+  @impl true
+  def info(adapter_meta, spec, opts) do
+    with_dynamic_cache(adapter_meta, :info, [spec, opts])
+  end
+
+  ## Helpers
+
+  @doc """
+  Helper function to use dynamic cache for internal primary cache storage
+  when needed.
+  """
+  def with_dynamic_cache(adapter_meta, action, args)
+
+  def with_dynamic_cache(%{cache: cache, primary_name: nil}, action, args) do
+    apply(cache.__primary__(), action, args)
+  end
+
+  def with_dynamic_cache(%{cache: cache, primary_name: primary_name}, action, args) do
+    cache.__primary__().with_dynamic_cache(primary_name, fn ->
+      apply(cache.__primary__(), action, args)
+    end)
+  end
+
+  @doc """
+  Fetches the value and TTL for a key from the local primary cache.
+
+  Called via RPC from peer nodes during lazy-pull replication. Returns
+  `{:ok, {value, ttl}}` on hit or `{:error, %Nebulex.KeyError{}}` on miss.
+  """
+  def fetch_with_ttl(adapter_meta, key, opts) do
+    with {:ok, value} <- with_dynamic_cache(adapter_meta, :fetch, [key, opts]),
+         {:ok, ttl} <- with_dynamic_cache(adapter_meta, :ttl, [key, opts]) do
+      {:ok, {value, ttl}}
+    end
+  end
+
+  ## Private Functions
+
+  defp build_query(%{select: select, query: query}) do
+    query = with {:q, q} <- query, do: {:query, q}
+
+    [query, select: select]
+  end
+
+  defp pull_and_cache(adapter_meta, key, opts, init_acc) do
+    with {:ok, {value, ttl}} <- rpc_first_peer(adapter_meta, key, opts, init_acc) do
+      # Cache locally by writing directly to the primary adapter
+      # (not through the write path) to avoid triggering
+      # an invalidation broadcast. Use the original TTL from the peer.
+      _ = with_dynamic_cache(adapter_meta, :put, [key, value, [ttl: ttl] ++ opts])
+
+      {:ok, {value, ttl}}
+    end
+  end
+
+  defp rpc_first_peer(%{pg_group: pg_group} = adapter_meta, key, opts, init_acc) do
+    # Validate common runtime options
+    opts = Options.validate_common_runtime_opts!(opts)
+    timeout = Keyword.fetch!(opts, :timeout)
+
+    pg_group
+    # Get the list of cache nodes
+    |> Cluster.pg_nodes()
+    # Delete the current node from the list
+    |> List.delete(node())
+    # Shuffle the list of nodes
+    |> Enum.shuffle()
+    # Call peer nodes until one returns a hit
+    |> Enum.reduce_while(init_acc, fn peer, acc ->
+      RPC.call(
+        peer,
+        __MODULE__,
+        :fetch_with_ttl,
+        [adapter_meta, key, opts],
+        timeout
+      )
+      |> case do
+        {:ok, _} = hit ->
+          {:halt, hit}
+
+        _error ->
+          {:cont, acc}
+      end
+    end)
+  end
+
+  defp pull_missing_keys(adapter_meta, keys, opts) do
+    Enum.reduce(keys, [], fn key, acc ->
+      init_acc = wrap_error Nebulex.KeyError, key: key
+
+      case pull_and_cache(adapter_meta, key, opts, init_acc) do
+        {:ok, {value, _ttl}} -> [{key, value} | acc]
+        _ -> acc
+      end
+    end)
+  end
+
+  defp select_from_kv(kv_list, {:key, :value}), do: kv_list
+  defp select_from_kv(kv_list, :key), do: Enum.map(kv_list, &elem(&1, 0))
+  defp select_from_kv(kv_list, :value), do: Enum.map(kv_list, &elem(&1, 1))
+end

--- a/lib/nebulex/adapters/lazy_replicated/cluster_monitor.ex
+++ b/lib/nebulex/adapters/lazy_replicated/cluster_monitor.ex
@@ -1,0 +1,37 @@
+defmodule Nebulex.Adapters.LazyReplicated.ClusterMonitor do
+  @moduledoc false
+
+  use GenServer
+
+  import Nebulex.Utils
+
+  alias Nebulex.Distributed.Cluster
+
+  ## API
+
+  @doc false
+  def start_link(%{name: name} = adapter_meta) do
+    name = camelize_and_concat([name, ClusterMonitor])
+
+    GenServer.start_link(__MODULE__, adapter_meta, name: name)
+  end
+
+  ## GenServer Callbacks
+
+  @impl true
+  def init(%{pg_group: pg_group} = adapter_meta) do
+    # Trap exit signals to run cleanup on termination
+    _ = Process.flag(:trap_exit, true)
+
+    # Join the PG group
+    :ok = Cluster.join(pg_group)
+
+    {:ok, %{adapter_meta: adapter_meta, pg_group: pg_group}}
+  end
+
+  @impl true
+  def terminate(_reason, %{pg_group: pg_group}) do
+    # Leave the PG group when the process terminates
+    :ok = Cluster.leave(pg_group)
+  end
+end

--- a/lib/nebulex/adapters/lazy_replicated/options.ex
+++ b/lib/nebulex/adapters/lazy_replicated/options.ex
@@ -1,0 +1,81 @@
+defmodule Nebulex.Adapters.LazyReplicated.Options do
+  @moduledoc false
+
+  alias Nebulex.Adapters.Coherent.Options, as: CoherentOptions
+
+  # Common runtime options
+  common_runtime_opts = [
+    timeout: [
+      type: :timeout,
+      required: false,
+      default: 5000,
+      doc: """
+      The time in **milliseconds** to wait for an RPC call to a peer node
+      to finish when pulling data on a cache miss.
+
+      This timeout applies to RPC calls made to peer nodes during the
+      lazy-pull replication. Set to `:infinity` to wait indefinitely.
+      """
+    ]
+  ]
+
+  # Nebulex common options
+  @nbx_start_opts Nebulex.Cache.Options.__compile_opts__() ++ Nebulex.Cache.Options.__start_opts__()
+
+  # Compilation time option schema
+  @compile_opts_schema CoherentOptions.shared_compile_opts() |> NimbleOptions.new!()
+
+  # Start options schema
+  @start_opts_schema CoherentOptions.shared_start_opts() |> NimbleOptions.new!()
+
+  # Common runtime options schema
+  @common_runtime_opts_schema NimbleOptions.new!(common_runtime_opts)
+
+  ## Docs API
+
+  # coveralls-ignore-start
+
+  @spec compile_options_docs() :: binary()
+  def compile_options_docs do
+    NimbleOptions.docs(@compile_opts_schema)
+  end
+
+  @spec start_options_docs() :: binary()
+  def start_options_docs do
+    NimbleOptions.docs(@start_opts_schema)
+  end
+
+  @spec common_runtime_options_docs() :: binary()
+  def common_runtime_options_docs do
+    NimbleOptions.docs(@common_runtime_opts_schema)
+  end
+
+  # coveralls-ignore-stop
+
+  ## Validation API
+
+  @spec validate_compile_opts!(keyword()) :: keyword()
+  def validate_compile_opts!(opts) do
+    NimbleOptions.validate!(opts, @compile_opts_schema)
+  end
+
+  @spec validate_start_opts!(keyword()) :: keyword()
+  def validate_start_opts!(opts) do
+    adapter_opts =
+      opts
+      |> Keyword.drop(@nbx_start_opts)
+      |> NimbleOptions.validate!(@start_opts_schema)
+
+    Keyword.merge(opts, adapter_opts)
+  end
+
+  @spec validate_common_runtime_opts!(keyword()) :: keyword()
+  def validate_common_runtime_opts!(opts) do
+    adapter_opts =
+      opts
+      |> Keyword.take([:timeout])
+      |> NimbleOptions.validate!(@common_runtime_opts_schema)
+
+    Keyword.merge(opts, adapter_opts)
+  end
+end

--- a/lib/nebulex/adapters/lazy_replicated/supervisor.ex
+++ b/lib/nebulex/adapters/lazy_replicated/supervisor.ex
@@ -1,0 +1,43 @@
+defmodule Nebulex.Adapters.LazyReplicated.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias Nebulex.Adapters.LazyReplicated.ClusterMonitor
+  alias Nebulex.Streams
+  alias Nebulex.Streams.Invalidator
+
+  ## API
+
+  @doc false
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg)
+  end
+
+  ## Supervisor callback
+
+  @impl true
+  def init({cache, adapter_meta, primary_opts, stream_opts}) do
+    # Get the primary cache module
+    primary = cache.__primary__()
+
+    # Common options
+    common_opts =
+      primary_opts
+      |> Keyword.take([:name])
+      |> Keyword.put(:cache, primary)
+
+    # Build stream options - register with primary cache since it's started first
+    stream_opts =
+      Keyword.merge(stream_opts, [broadcast_fun: :broadcast_from] ++ common_opts)
+
+    children = [
+      {primary, primary_opts},
+      {Streams, stream_opts},
+      {Invalidator, common_opts},
+      {ClusterMonitor, adapter_meta}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/test/nebulex/adapters/lazy_replicated_test.exs
+++ b/test/nebulex/adapters/lazy_replicated_test.exs
@@ -1,0 +1,332 @@
+defmodule Nebulex.Adapters.LazyReplicatedCacheTest do
+  use Nebulex.NodeCase
+
+  # Inherit tests
+  use Nebulex.CacheTestCase
+
+  import Nebulex.CacheCase
+
+  alias Nebulex.Adapter
+  alias Nebulex.Distributed.TestCache.{LazyReplicatedCache, LazyReplicatedNilCache}
+
+  @moduletag capture_log: true
+
+  @primary :"primary@127.0.0.1"
+  @cache_name :lazy_replicated_cache
+
+  setup do
+    cluster = :lists.usort([@primary | Application.get_env(:nebulex_distributed, :nodes, [])])
+    nodes = [node() | Node.list()]
+
+    node_pid_list =
+      start_caches(
+        nodes,
+        [{LazyReplicatedCache, name: @cache_name}, {LazyReplicatedNilCache, []}]
+      )
+
+    # Wait for caches to be ready on all nodes
+    :ok = Process.sleep(100)
+
+    default_dynamic_cache = LazyReplicatedCache.get_dynamic_cache()
+    _ = LazyReplicatedCache.put_dynamic_cache(@cache_name)
+
+    on_exit(fn ->
+      _ = LazyReplicatedCache.put_dynamic_cache(default_dynamic_cache)
+
+      :ok = Process.sleep(100)
+
+      stop_caches(node_pid_list)
+    end)
+
+    {:ok,
+     cache: LazyReplicatedCache,
+     name: @cache_name,
+     cluster: cluster,
+     nodes: nodes,
+     nil_cache: LazyReplicatedNilCache}
+  end
+
+  describe "c:init/1" do
+    test "initializes the primary store metadata" do
+      adapter_meta =
+        @cache_name
+        |> Adapter.lookup_meta()
+        |> Map.fetch!(:primary_name)
+        |> Adapter.lookup_meta()
+
+      assert adapter_meta.adapter == Nebulex.Adapters.Local
+      assert adapter_meta.backend == :ets
+    end
+
+    test "raises an exception because invalid primary store" do
+      msg = "invalid value for :adapter option: the module Invalid was not compiled"
+
+      assert_raise NimbleOptions.ValidationError, ~r"#{msg}", fn ->
+        defmodule Demo do
+          use Nebulex.Cache,
+            otp_app: :nebulex,
+            adapter: Nebulex.Adapters.LazyReplicated,
+            adapter_opts: [primary_storage_adapter: Invalid]
+        end
+      end
+    end
+  end
+
+  describe "cluster membership" do
+    test "nodes returns all cluster nodes", %{nodes: nodes} do
+      assert LazyReplicatedCache.nodes() |> Enum.sort() == Enum.sort(nodes)
+    end
+
+    test "join and leave cluster", %{nodes: nodes, name: name} do
+      assert LazyReplicatedCache.nodes() |> Enum.sort() == Enum.sort(nodes)
+
+      LazyReplicatedCache.with_dynamic_cache(name, fn ->
+        :ok = LazyReplicatedCache.leave_cluster()
+
+        assert_eventually fn ->
+          assert LazyReplicatedCache.nodes() |> Enum.sort() == (nodes -- [node()]) |> Enum.sort()
+        end
+      end)
+
+      LazyReplicatedCache.with_dynamic_cache(name, fn ->
+        :ok = LazyReplicatedCache.join_cluster()
+
+        assert_eventually fn ->
+          assert LazyReplicatedCache.nodes() |> Enum.sort() == Enum.sort(nodes)
+        end
+      end)
+    end
+  end
+
+  describe "local reads" do
+    test "local cache hit returns data immediately" do
+      assert LazyReplicatedCache.put("local_key", "local_value") == :ok
+      assert LazyReplicatedCache.get!("local_key") == "local_value"
+    end
+
+    test "put_all and get work locally" do
+      assert LazyReplicatedCache.put_all([{:a, 1}, {:b, 2}, {:c, 3}]) == :ok
+      assert LazyReplicatedCache.get!(:a) == 1
+      assert LazyReplicatedCache.get!(:b) == 2
+      assert LazyReplicatedCache.get!(:c) == 3
+    end
+  end
+
+  describe "lazy-pull replication" do
+    test "cache miss pulls data from peer node", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put a value on a remote node
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :pull_key, "remote_value", []])
+
+      assert :rpc.call(remote_node, LazyReplicatedCache, :get!, [name, :pull_key, nil, []]) ==
+               "remote_value"
+
+      # Primary node doesn't have the value locally yet
+      # But fetch should pull from the peer transparently
+      assert LazyReplicatedCache.get!(:pull_key) == "remote_value"
+    end
+
+    test "pulled data is cached locally for subsequent reads", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :cached_pull, "value", []])
+
+      # First read: pulls from peer
+      assert LazyReplicatedCache.get!(:cached_pull) == "value"
+
+      # Verify it's now in the local cache
+      assert LazyReplicatedCache.has_key?(:cached_pull) == {:ok, true}
+    end
+
+    test "pulled data preserves TTL from peer", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node with a TTL
+      :ok =
+        :rpc.call(remote_node, LazyReplicatedCache, :put, [
+          name,
+          :ttl_pull_key,
+          "value",
+          [ttl: :timer.seconds(60)]
+        ])
+
+      # Pull from peer via get
+      assert LazyReplicatedCache.get!(:ttl_pull_key) == "value"
+
+      # Verify the local copy has a TTL (not :infinity)
+      assert {:ok, ttl} = LazyReplicatedCache.ttl(:ttl_pull_key)
+      assert is_integer(ttl) and ttl > 0 and ttl <= :timer.seconds(60)
+    end
+
+    test "returns nil when no peer has the data" do
+      # No node has this key
+      assert LazyReplicatedCache.get(:missing_key) == {:ok, nil}
+    end
+
+    test "take pulls from peer and returns value", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :take_key, "take_value", []])
+
+      # Take from primary (should pull from peer)
+      assert LazyReplicatedCache.take!(:take_key) == "take_value"
+    end
+
+    test "has_key? checks peers when key is not local", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node only
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :hk_key, "value", []])
+
+      # Primary doesn't have it locally, but has_key? should find it on a peer
+      assert LazyReplicatedCache.has_key?(:hk_key) == {:ok, true}
+    end
+
+    test "has_key? returns false when no peer has the key" do
+      assert LazyReplicatedCache.has_key?(:nonexistent_key) == {:ok, false}
+    end
+
+    test "ttl checks peers when key is not local", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node with a TTL
+      :ok =
+        :rpc.call(remote_node, LazyReplicatedCache, :put, [
+          name,
+          :ttl_key,
+          "value",
+          [ttl: :timer.seconds(60)]
+        ])
+
+      # Primary doesn't have it locally, but ttl should find it on a peer
+      assert {:ok, ttl} = LazyReplicatedCache.ttl(:ttl_key)
+      assert is_integer(ttl) and ttl > 0
+    end
+
+    test "ttl returns error when no peer has the key" do
+      assert {:error, %Nebulex.KeyError{key: :missing_ttl_key}} =
+               LazyReplicatedCache.ttl(:missing_ttl_key)
+    end
+
+    test "get_all pulls missing keys from peers", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put some keys on remote node only
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :ga_remote1, "r1", []])
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :ga_remote2, "r2", []])
+
+      # Put one key locally
+      :ok = LazyReplicatedCache.put(:ga_local, "local")
+
+      # get_all with all three keys - should pull missing from peer
+      assert {:ok, results} = LazyReplicatedCache.get_all(in: [:ga_local, :ga_remote1, :ga_remote2])
+      assert Map.new(results) == %{ga_local: "local", ga_remote1: "r1", ga_remote2: "r2"}
+    end
+
+    test "get_all pulls missing keys and caches them locally", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node only
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :ga_cached, "cached_val", []])
+
+      # get_all triggers pull
+      assert LazyReplicatedCache.get_all!(in: [:ga_cached]) == [{:ga_cached, "cached_val"}]
+
+      # Now it should be cached locally
+      assert LazyReplicatedCache.has_key?(:ga_cached) == {:ok, true}
+    end
+
+    test "get_all with select: :value pulls from peers", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :ga_val_key, "val", []])
+
+      assert {:ok, values} = LazyReplicatedCache.get_all(in: [:ga_val_key], select: :value)
+      assert "val" in values
+    end
+
+    test "get_all with select: :key pulls from peers", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :ga_key_only, "val", []])
+
+      assert {:ok, keys} = LazyReplicatedCache.get_all(in: [:ga_key_only], select: :key)
+      assert :ga_key_only in keys
+    end
+  end
+
+  describe "distributed invalidation" do
+    test "write invalidates entry on remote nodes", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put a value on remote node first
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :inv_key, "remote_value", []])
+
+      assert :rpc.call(remote_node, LazyReplicatedCache, :get!, [name, :inv_key, nil, []]) ==
+               "remote_value"
+
+      # Now put on primary node - this should trigger invalidation on remote
+      assert LazyReplicatedCache.put(:inv_key, "primary_value") == :ok
+      assert LazyReplicatedCache.get!(:inv_key) == "primary_value"
+
+      # Wait for invalidation to propagate, then remote should pull new value
+      assert_eventually fn ->
+        assert :rpc.call(remote_node, LazyReplicatedCache, :get!, [name, :inv_key, nil, []]) ==
+                 "primary_value"
+      end
+    end
+
+    test "write + read from another node returns new value via pull", %{
+      name: name,
+      cluster: cluster
+    } do
+      remote_node = find_remote_node(cluster)
+
+      # Put on primary node
+      assert LazyReplicatedCache.put(:sync_key, "primary_value") == :ok
+
+      # Wait for invalidation to propagate (in case remote had old data)
+      :ok = Process.sleep(100)
+
+      # Remote node reads - should pull from primary
+      assert :rpc.call(remote_node, LazyReplicatedCache, :get!, [name, :sync_key, nil, []]) ==
+               "primary_value"
+    end
+
+    test "delete invalidates on remote nodes", %{name: name, cluster: cluster} do
+      remote_node = find_remote_node(cluster)
+
+      # Put on remote node
+      :ok = :rpc.call(remote_node, LazyReplicatedCache, :put, [name, :del_key, "value", []])
+
+      assert :rpc.call(remote_node, LazyReplicatedCache, :get!, [name, :del_key, nil, []]) ==
+               "value"
+
+      # Delete on primary
+      :ok = LazyReplicatedCache.delete(:del_key)
+
+      # Wait for invalidation
+      assert_eventually fn ->
+        assert :rpc.call(remote_node, LazyReplicatedCache, :get, [name, :del_key, nil, []]) ==
+                 {:ok, nil}
+      end
+    end
+  end
+
+  describe "info" do
+    test "returns cache info" do
+      assert LazyReplicatedNilCache.info!() != %{}
+    end
+  end
+
+  ## Private functions
+
+  defp find_remote_node(cluster) do
+    cluster
+    |> Enum.reject(&(&1 == node()))
+    |> Enum.random()
+  end
+end

--- a/test/support/test_cache.ex
+++ b/test/support/test_cache.ex
@@ -140,6 +140,26 @@ defmodule Nebulex.Distributed.TestCache do
     use Commons
   end
 
+  defmodule LazyReplicatedCache do
+    @moduledoc false
+    use Nebulex.Cache,
+      otp_app: :nebulex_distributed,
+      adapter: Nebulex.Adapters.LazyReplicated,
+      adapter_opts: [primary_storage_adapter: Nebulex.Adapters.Local]
+
+    use Commons
+  end
+
+  defmodule LazyReplicatedNilCache do
+    @moduledoc false
+    use Nebulex.Cache,
+      otp_app: :nebulex_distributed,
+      adapter: Nebulex.Adapters.LazyReplicated,
+      adapter_opts: [primary_storage_adapter: Nebulex.Adapters.Nil]
+
+    use Commons
+  end
+
   defmodule TestNodeSelector do
     @moduledoc false
 


### PR DESCRIPTION
Implement Nebulex.Adapters.LazyReplicated — a replicated cache topology where each node maintains a local cache with distributed invalidation via Nebulex.Streams. Cache misses transparently pull data from peer nodes via RPC, preserving the original TTL. Over time, frequently accessed data naturally replicates across all nodes that read it.

Key design decisions:
- Write-invalidate protocol (not push-based) avoids LWW conflicts and simplifies node joins (start empty, fill on demand)
- All read ops (fetch, take, has_key?, ttl, get_all with in: keys) check peers on local miss; general queries are local-only
- fetch_with_ttl/3 fetches value + TTL in a single RPC call
- Writes to local primary bypass Streams to avoid re-broadcasting
- Cluster membership via :pg groups (no hash ring needed)
- Reuses Coherent shared compile/start options

Closes #9