### PR TITLE
feat(replicated): add anti-entropy reconciliation

### DIFF
--- a/lib/nebulex/adapters/replicated.ex
+++ b/lib/nebulex/adapters/replicated.ex
@@ -9,6 +9,7 @@ defmodule Nebulex.Adapters.Replicated do
     * Writes are applied locally and replicated to all peers via buffered RPC.
     * Double-buffered outbox and inbox for high-throughput batched replication.
     * "Newer version wins" conflict resolution via monotonic versioning.
+    * Optional anti-entropy reconciliation to detect and repair data drift.
     * Configurable primary storage adapter.
 
   ## Replicated Cache Topology
@@ -344,6 +345,99 @@ defmodule Nebulex.Adapters.Replicated do
         }
         ```
 
+  ### Anti-entropy events
+
+  When anti-entropy reconciliation is enabled (`:anti_entropy_interval`),
+  the following Telemetry span events are emitted each cycle:
+
+    * `telemetry_prefix ++ [:anti_entropy, :start]` - Dispatched when
+      an anti-entropy cycle starts.
+
+      * Measurements: `%{system_time: non_neg_integer}`
+      * Metadata:
+
+        ```
+        %{
+          adapter_meta: %{optional(atom) => term},
+          node: atom,
+          peer: atom
+        }
+        ```
+
+    * `telemetry_prefix ++ [:anti_entropy, :stop]` - Dispatched when
+      an anti-entropy cycle completes.
+
+      * Measurements: `%{duration: non_neg_integer}`
+      * Metadata:
+
+        ```
+        %{
+          adapter_meta: %{optional(atom) => term},
+          node: atom,
+          peer: atom,
+          repaired: non_neg_integer,
+          divergent_buckets: non_neg_integer
+        }
+        ```
+
+    * `telemetry_prefix ++ [:anti_entropy, :exception]` - Dispatched when
+      an anti-entropy cycle raises an exception (e.g., RPC failure to the
+      selected peer).
+
+      * Measurements: `%{duration: non_neg_integer}`
+      * Metadata:
+
+        ```
+        %{
+          adapter_meta: %{optional(atom) => term},
+          node: atom,
+          peer: atom,
+          kind: :error | :exit | :throw,
+          reason: term(),
+          stacktrace: [term()]
+        }
+        ```
+
+  ## Anti-Entropy Reconciliation
+
+  The replicated adapter supports optional anti-entropy reconciliation
+  to detect and repair data drift between nodes. This can happen after
+  missed replication batches (e.g., brief network partitions or node
+  outages).
+
+  When enabled via `:anti_entropy_interval`, a background process runs
+  periodically on each node:
+
+    1. Picks a random peer.
+    2. Builds a bucket-hashed digest (1024 fixed buckets, XOR of key/value
+       hashes) of the local cache.
+    3. Fetches the peer's digest via RPC.
+    4. Compares digests to find divergent buckets.
+    5. For divergent buckets, fetches the peer's actual entries (with TTLs).
+    6. Writes them through the inbox, preserving "newer version wins"
+       conflict resolution.
+
+  This approach is based on the anti-entropy reconciliation technique
+  originally described in the Amazon Dynamo paper (DeCandia et al., 2007)
+  and widely adopted by distributed databases like Apache Cassandra and
+  Riak. The specific implementation follows Riak's Active Anti-Entropy
+  (AAE) design most closely: instead of building a full Merkle tree over
+  individual keys (expensive to build and compare), keys are hashed into
+  a fixed number of buckets and each bucket stores the XOR of its
+  key/value hashes. This bucket-based approach provides precise
+  divergence detection with minimal overhead — only the entries in
+  divergent buckets need to be fetched and compared.
+
+  ### Configuration
+
+      config :my_app, MyApp.ReplicatedCache,
+        replication: [
+          interval: :timer.seconds(1),
+          anti_entropy_interval: :timer.minutes(1)
+        ]
+
+  Omit `:anti_entropy_interval` to disable (default).
+
   ## Caveats
 
     * _**Replication Latency**_: There is a window (up to the
@@ -497,7 +591,8 @@ defmodule Nebulex.Adapters.Replicated do
       outbox: outbox,
       replication_timeout: Keyword.fetch!(replication_opts, :timeout),
       replication_retries: Keyword.fetch!(replication_opts, :retries),
-      replication_retry_delay: Keyword.fetch!(replication_opts, :retry_delay)
+      replication_retry_delay: Keyword.fetch!(replication_opts, :retry_delay),
+      anti_entropy_interval: Keyword.get(replication_opts, :anti_entropy_interval)
     }
 
     # Prepare child spec

--- a/lib/nebulex/adapters/replicated/anti_entropy.ex
+++ b/lib/nebulex/adapters/replicated/anti_entropy.ex
@@ -1,0 +1,193 @@
+defmodule Nebulex.Adapters.Replicated.AntiEntropy do
+  @moduledoc false
+
+  use GenServer
+
+  import Nebulex.Utils
+
+  alias Nebulex.Adapters.Replicated
+  alias Nebulex.Distributed.{Cluster, RPC}
+  alias Nebulex.Telemetry
+
+  # State
+  defstruct [:adapter_meta, :interval, :timer_ref]
+
+  # Number of fixed buckets for the hash digest. Each bucket stores the XOR
+  # of hash(key, value_hash) for all keys that fall into it. 1024 gives a
+  # good balance between digest size (~4 KB) and divergence granularity.
+  @buckets 1024
+
+  ## API
+
+  @doc false
+  def start_link(%{name: name} = adapter_meta) do
+    name = camelize_and_concat([name, AntiEntropy])
+
+    GenServer.start_link(__MODULE__, adapter_meta, name: name)
+  end
+
+  ## GenServer Callbacks
+
+  @impl true
+  def init(adapter_meta) do
+    interval = adapter_meta.anti_entropy_interval
+    timer_ref = schedule_cycle(interval)
+
+    state = %__MODULE__{
+      adapter_meta: adapter_meta,
+      interval: interval,
+      timer_ref: timer_ref
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:run, %__MODULE__{adapter_meta: adapter_meta, interval: interval} = state) do
+    peers = get_peers(adapter_meta.pg_group)
+
+    if peers != [] do
+      peer = Enum.random(peers)
+
+      reconcile(peer, adapter_meta)
+    end
+
+    timer_ref = schedule_cycle(interval)
+
+    {:noreply, %{state | timer_ref: timer_ref}}
+  rescue
+    # coveralls-ignore-start
+    _error -> {:noreply, %{state | timer_ref: schedule_cycle(interval)}}
+  catch
+    :exit, _reason ->
+      {:noreply, %{state | timer_ref: schedule_cycle(interval)}}
+      # coveralls-ignore-stop
+  end
+
+  ## Public functions (called locally and via RPC)
+
+  @doc false
+  def build_buckets(adapter_meta) do
+    adapter_meta
+    |> Replicated.with_dynamic_cache(:stream!, [
+      [select: {:key, :value}],
+      [timeout: :infinity]
+    ])
+    |> Enum.reduce(:array.new(@buckets, default: 0), fn {key, value}, acc ->
+      idx = :erlang.phash2(key, @buckets)
+      hash = :erlang.phash2({key, :erlang.phash2(value)})
+      current = :array.get(idx, acc)
+
+      :array.set(idx, Bitwise.bxor(current, hash), acc)
+    end)
+    |> then(&for i <- 0..(@buckets - 1), do: :array.get(i, &1))
+  end
+
+  @doc false
+  def entries_for_buckets(adapter_meta, bucket_indices) do
+    bucket_set = MapSet.new(bucket_indices)
+
+    adapter_meta
+    |> Replicated.with_dynamic_cache(:stream!, [
+      [select: {:key, :value}],
+      [timeout: :infinity]
+    ])
+    |> Stream.filter(fn {key, _value} ->
+      MapSet.member?(bucket_set, :erlang.phash2(key, @buckets))
+    end)
+    |> Stream.map(fn {key, value} ->
+      case Replicated.with_dynamic_cache(adapter_meta, :ttl, [key, []]) do
+        {:ok, ttl} -> {key, {:put, [key, value, [ttl: ttl]]}}
+        _error -> nil
+      end
+    end)
+    |> Stream.reject(&is_nil/1)
+    |> Enum.to_list()
+  end
+
+  ## Private Functions
+
+  defp get_peers(pg_group) do
+    pg_group
+    |> Cluster.pg_nodes()
+    |> List.delete(node())
+  end
+
+  defp reconcile(peer, adapter_meta) do
+    event = adapter_meta.telemetry_prefix ++ [:anti_entropy]
+
+    metadata = %{
+      adapter_meta: adapter_meta,
+      node: node(),
+      peer: peer
+    }
+
+    Telemetry.span(event, metadata, fn ->
+      {repaired, divergent_buckets} = do_reconcile(peer, adapter_meta)
+
+      {repaired, Map.merge(metadata, %{repaired: repaired, divergent_buckets: divergent_buckets})}
+    end)
+  end
+
+  @doc false
+  def do_reconcile(
+        peer,
+        %{
+          replication_timeout: replication_timeout,
+          inbox: inbox
+        } = adapter_meta
+      ) do
+    # Build local bucket hashes
+    local_buckets = build_buckets(adapter_meta)
+
+    # Get peer's bucket hashes via RPC
+    peer_buckets =
+      RPC.call(
+        peer,
+        __MODULE__,
+        :build_buckets,
+        [adapter_meta],
+        replication_timeout
+      )
+
+    # Find divergent bucket indices
+    divergent =
+      local_buckets
+      |> Enum.zip(peer_buckets)
+      |> Enum.with_index()
+      |> Enum.filter(fn {{local, remote}, _idx} -> local != remote end)
+      |> Enum.map(fn {_, idx} -> idx end)
+
+    case divergent do
+      [] ->
+        {0, 0}
+
+      _ ->
+        # Fetch entries for divergent buckets from peer
+        peer_entries =
+          RPC.call(
+            peer,
+            __MODULE__,
+            :entries_for_buckets,
+            [adapter_meta, divergent],
+            replication_timeout
+          )
+
+        # Write to inbox — "newer version wins" handles conflicts
+        version = System.monotonic_time()
+
+        inbox_entries =
+          Enum.map(peer_entries, fn {key, command} ->
+            {key, {command, :remote}, version}
+          end)
+
+        :ok = PartitionedBuffer.Map.put_all_newer(inbox, inbox_entries)
+
+        {Enum.count(peer_entries), Enum.count(divergent)}
+    end
+  end
+
+  defp schedule_cycle(interval) do
+    Process.send_after(self(), :run, interval)
+  end
+end

--- a/lib/nebulex/adapters/replicated/options.ex
+++ b/lib/nebulex/adapters/replicated/options.ex
@@ -75,6 +75,21 @@ defmodule Nebulex.Adapters.Replicated.Options do
       Maps to the `:partitions` option of `PartitionedBuffer.Map`.
       Defaults to `System.schedulers_online()`.
       """
+    ],
+    anti_entropy_interval: [
+      type: :pos_integer,
+      required: false,
+      doc: """
+      Interval in milliseconds between anti-entropy reconciliation
+      cycles. When set, a background process periodically picks a
+      random peer, compares bucket-hashed Merkle digests of the local
+      and remote caches, and repairs only the divergent keys by
+      writing them through the inbox (preserving "newer version wins"
+      semantics).
+
+      Disabled by default (not present). Set to a positive integer
+      to enable, e.g., `:timer.minutes(1)`.
+      """
     ]
   ]
 

--- a/lib/nebulex/adapters/replicated/supervisor.ex
+++ b/lib/nebulex/adapters/replicated/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Nebulex.Adapters.Replicated.Supervisor do
 
   use Supervisor
 
-  alias Nebulex.Adapters.Replicated.{ClusterMonitor, Replicator}
+  alias Nebulex.Adapters.Replicated.{AntiEntropy, ClusterMonitor, Replicator}
 
   ## API
 
@@ -18,27 +18,35 @@ defmodule Nebulex.Adapters.Replicated.Supervisor do
   def init({cache, adapter_meta, primary_opts, buffer_opts}) do
     primary = cache.__primary__()
 
-    children = [
-      {primary, primary_opts},
-      Supervisor.child_spec(
-        {PartitionedBuffer.Map,
-         Keyword.merge(buffer_opts,
-           name: adapter_meta.inbox,
-           processor: {Replicator, :process_inbox, [adapter_meta]}
-         )},
-        id: adapter_meta.inbox
-      ),
-      Supervisor.child_spec(
-        {PartitionedBuffer.Map,
-         Keyword.merge(buffer_opts,
-           name: adapter_meta.outbox,
-           processor: {Replicator, :process_outbox, [adapter_meta]}
-         )},
-        id: adapter_meta.outbox
-      ),
-      {ClusterMonitor, adapter_meta}
-    ]
+    children =
+      [
+        {primary, primary_opts},
+        Supervisor.child_spec(
+          {PartitionedBuffer.Map,
+           Keyword.merge(buffer_opts,
+             name: adapter_meta.inbox,
+             processor: {Replicator, :process_inbox, [adapter_meta]}
+           )},
+          id: adapter_meta.inbox
+        ),
+        Supervisor.child_spec(
+          {PartitionedBuffer.Map,
+           Keyword.merge(buffer_opts,
+             name: adapter_meta.outbox,
+             processor: {Replicator, :process_outbox, [adapter_meta]}
+           )},
+          id: adapter_meta.outbox
+        ),
+        {ClusterMonitor, adapter_meta}
+      ] ++ maybe_anti_entropy(adapter_meta)
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
+
+  defp maybe_anti_entropy(%{anti_entropy_interval: interval} = adapter_meta)
+       when is_integer(interval) do
+    [{AntiEntropy, adapter_meta}]
+  end
+
+  defp maybe_anti_entropy(_adapter_meta), do: []
 end

--- a/lib/nebulex/distributed/ring_monitor.ex
+++ b/lib/nebulex/distributed/ring_monitor.ex
@@ -39,7 +39,7 @@ defmodule Nebulex.Distributed.RingMonitor do
   alias Nebulex.Telemetry
 
   # State
-  defstruct adapter_meta: nil, ring: nil, pg_ref: nil, rejoin_interval: nil, rejoin_timer_ref: nil
+  defstruct [:adapter_meta, :ring, :pg_ref, :rejoin_interval, :rejoin_timer_ref]
 
   ## API
 

--- a/test/nebulex/adapters/replicated_test.exs
+++ b/test/nebulex/adapters/replicated_test.exs
@@ -8,9 +8,11 @@ defmodule Nebulex.Adapters.ReplicatedCacheTest do
   import Nebulex.CacheCase
 
   alias Nebulex.Adapter
-  alias Nebulex.Adapters.Replicated.Replicator
+  alias Nebulex.Adapters.Replicated.{AntiEntropy, Replicator}
+  alias Nebulex.Distributed.Cluster
   alias Nebulex.Distributed.TestCache.{ReplicatedCache, ReplicatedNilCache}
   alias Nebulex.Telemetry
+  alias Nebulex.Utils
 
   @moduletag capture_log: true
 
@@ -522,6 +524,282 @@ defmodule Nebulex.Adapters.ReplicatedCacheTest do
 
       # Cleanup: stop the restarted cache
       :ok = ReplicatedCache.stop()
+    end
+  end
+
+  describe "anti-entropy" do
+    test "build_buckets returns a list of 1024 bucket hashes" do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+
+      # Put some data
+      assert ReplicatedCache.put(:ae_b1, "v1") == :ok
+      assert ReplicatedCache.put(:ae_b2, "v2") == :ok
+
+      buckets = AntiEntropy.build_buckets(adapter_meta)
+
+      assert is_list(buckets)
+      assert Enum.count(buckets) == 1024
+
+      # At least some buckets should be non-zero
+      assert Enum.any?(buckets, &(&1 != 0))
+    end
+
+    test "build_buckets is deterministic for the same data" do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+
+      assert ReplicatedCache.put(:ae_det1, "value1") == :ok
+      assert ReplicatedCache.put(:ae_det2, "value2") == :ok
+
+      buckets1 = AntiEntropy.build_buckets(adapter_meta)
+      buckets2 = AntiEntropy.build_buckets(adapter_meta)
+
+      assert buckets1 == buckets2
+    end
+
+    test "build_buckets differs when data diverges", %{cluster: cluster} do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      remote_node = find_remote_node(cluster)
+
+      # Put data only on the remote node's primary (bypass replication)
+      :rpc.call(remote_node, Nebulex.Adapters.Replicated, :with_dynamic_cache, [
+        adapter_meta,
+        :put,
+        [:ae_div_key, "divergent_value", []]
+      ])
+
+      local_buckets = AntiEntropy.build_buckets(adapter_meta)
+
+      remote_buckets =
+        :rpc.call(remote_node, AntiEntropy, :build_buckets, [adapter_meta])
+
+      assert local_buckets != remote_buckets
+    end
+
+    test "entries_for_buckets returns entries in the given buckets" do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+
+      assert ReplicatedCache.put(:ae_efb1, "v1") == :ok
+      assert ReplicatedCache.put(:ae_efb2, "v2", ttl: :timer.seconds(60)) == :ok
+
+      # Find which bucket :ae_efb1 falls into
+      bucket_idx = :erlang.phash2(:ae_efb1, 1024)
+
+      entries = AntiEntropy.entries_for_buckets(adapter_meta, [bucket_idx])
+
+      # Should contain at least :ae_efb1
+      entries_map = Map.new(entries)
+      assert Map.has_key?(entries_map, :ae_efb1)
+
+      # Verify the command format
+      {:put, [key, value, opts]} = entries_map[:ae_efb1]
+      assert key == :ae_efb1
+      assert value == "v1"
+      assert Keyword.has_key?(opts, :ttl)
+    end
+
+    test "do_reconcile repairs divergent entries from peer", %{cluster: cluster} do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      remote_node = find_remote_node(cluster)
+
+      # Put data only on the remote node's primary (bypass replication)
+      :rpc.call(remote_node, Nebulex.Adapters.Replicated, :with_dynamic_cache, [
+        adapter_meta,
+        :put,
+        [:ae_direct_key, "direct_value", []]
+      ])
+
+      # Verify key does NOT exist locally
+      assert ReplicatedCache.get(:ae_direct_key) == {:ok, nil}
+
+      # Call do_reconcile directly (in test process, ensures coverage)
+      {repaired, divergent_buckets} = AntiEntropy.do_reconcile(remote_node, adapter_meta)
+
+      assert repaired > 0
+      assert divergent_buckets > 0
+
+      # Wait for inbox processing
+      assert_eventually fn ->
+        assert ReplicatedCache.get!(:ae_direct_key) == "direct_value"
+      end
+    end
+
+    test "reconcile repairs divergent keys from peer", %{cluster: cluster} do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      remote_node = find_remote_node(cluster)
+
+      # Put data only on the remote node's primary (bypass replication)
+      :rpc.call(remote_node, Nebulex.Adapters.Replicated, :with_dynamic_cache, [
+        adapter_meta,
+        :put,
+        [:ae_repair_key, "repaired_value", []]
+      ])
+
+      # Verify key does NOT exist locally
+      assert ReplicatedCache.get(:ae_repair_key) == {:ok, nil}
+
+      # Start anti-entropy for this test (it's not started by default)
+      ae_meta = Map.put(adapter_meta, :anti_entropy_interval, 500)
+      {:ok, ae_pid} = AntiEntropy.start_link(ae_meta)
+
+      # Wait for at least one cycle to run
+      :ok = Process.sleep(700)
+
+      # Key should now be repaired locally via inbox
+      assert_eventually fn ->
+        assert ReplicatedCache.get!(:ae_repair_key) == "repaired_value"
+      end
+
+      # Cleanup
+      GenServer.stop(ae_pid)
+    end
+
+    test "anti-entropy emits telemetry span events", %{cluster: cluster} do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      remote_node = find_remote_node(cluster)
+
+      # Put data only on the remote node to create divergence
+      :rpc.call(remote_node, Nebulex.Adapters.Replicated, :with_dynamic_cache, [
+        adapter_meta,
+        :put,
+        [:ae_tel_key, "tel_value", []]
+      ])
+
+      started = @telemetry_prefix ++ [:anti_entropy, :start]
+      stopped = @telemetry_prefix ++ [:anti_entropy, :stop]
+
+      with_telemetry_handler __MODULE__, [started, stopped], fn ->
+        ae_meta = Map.put(adapter_meta, :anti_entropy_interval, 500)
+        {:ok, ae_pid} = AntiEntropy.start_link(ae_meta)
+
+        assert_receive {^started, %{system_time: _}, %{adapter_meta: _, node: node, peer: peer}},
+                       5000
+
+        assert node == node()
+
+        pg_nodes = Cluster.pg_nodes(adapter_meta.pg_group)
+
+        assert peer in Enum.reject(pg_nodes, &(&1 == node()))
+
+        assert_receive {^stopped, %{duration: _},
+                        %{
+                          adapter_meta: _,
+                          node: _,
+                          peer: _,
+                          repaired: repaired,
+                          divergent_buckets: divergent_buckets
+                        }},
+                       5000
+
+        assert is_integer(repaired)
+        assert is_integer(divergent_buckets)
+
+        GenServer.stop(ae_pid)
+      end
+    end
+
+    test "anti-entropy with no peers does nothing" do
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      ae_meta = Map.put(adapter_meta, :anti_entropy_interval, 100)
+
+      # Temporarily leave the PG group so there are no peers
+      :ok = Cluster.leave(adapter_meta.pg_group)
+
+      {:ok, ae_pid} = AntiEntropy.start_link(ae_meta)
+
+      # Wait for a cycle — should not crash
+      :ok = Process.sleep(200)
+
+      assert Process.alive?(ae_pid)
+
+      GenServer.stop(ae_pid)
+
+      # Rejoin
+      :ok = Cluster.join(adapter_meta.pg_group)
+    end
+
+    test "reconcile does nothing when caches are in sync", %{name: name, cluster: cluster} do
+      # Put data and wait for replication so all nodes are in sync
+      assert ReplicatedCache.put(:ae_sync1, "v1") == :ok
+      assert ReplicatedCache.put(:ae_sync2, "v2") == :ok
+
+      assert_remote_nodes(cluster, :get!, [name, :ae_sync1, nil, []], fn result ->
+        assert result == "v1"
+      end)
+
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+      stopped = @telemetry_prefix ++ [:anti_entropy, :stop]
+
+      with_telemetry_handler __MODULE__, [stopped], fn ->
+        ae_meta = Map.put(adapter_meta, :anti_entropy_interval, 500)
+        {:ok, ae_pid} = AntiEntropy.start_link(ae_meta)
+
+        assert_receive {^stopped, %{duration: _}, %{repaired: 0, divergent_buckets: 0}},
+                       5000
+
+        GenServer.stop(ae_pid)
+      end
+    end
+
+    test "entries_for_buckets skips entries when TTL lookup fails" do
+      primary = ReplicatedCache.__primary__()
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+
+      assert ReplicatedCache.put(:ae_ttl_ok, "good") == :ok
+      assert ReplicatedCache.put(:ae_ttl_fail, "bad") == :ok
+
+      # Stub TTL to fail for :ae_ttl_fail
+      primary
+      |> stub(:ttl, fn
+        :ae_ttl_fail, _opts ->
+          {:error, %Nebulex.KeyError{key: :ae_ttl_fail, reason: :not_found}}
+
+        key, opts ->
+          call_original(primary, :ttl, [key, opts])
+      end)
+
+      bucket_ok = :erlang.phash2(:ae_ttl_ok, 1024)
+      bucket_fail = :erlang.phash2(:ae_ttl_fail, 1024)
+
+      entries_map =
+        adapter_meta
+        |> AntiEntropy.entries_for_buckets(Enum.uniq([bucket_ok, bucket_fail]))
+        |> Map.new()
+
+      # :ae_ttl_fail should be filtered out
+      refute Map.has_key?(entries_map, :ae_ttl_fail)
+      assert Map.has_key?(entries_map, :ae_ttl_ok)
+    end
+
+    test "anti-entropy is not started when interval is not configured" do
+      # The default setup doesn't set anti_entropy_interval,
+      # so AntiEntropy should not be in the supervision tree
+      adapter_meta = Adapter.lookup_meta(@cache_name)
+
+      ae_name = Utils.camelize_and_concat([@cache_name, "AntiEntropy"])
+
+      assert Process.whereis(ae_name) == nil
+      assert adapter_meta[:anti_entropy_interval] == nil
+    end
+
+    test "cache started with anti_entropy_interval runs the GenServer" do
+      cache_name = :replicated_ae_cache
+
+      cache_opts = [
+        name: cache_name,
+        replication: [interval: 100, anti_entropy_interval: 500]
+      ]
+
+      {:ok, pid} = ReplicatedCache.start_link(cache_opts)
+
+      # The GenServer name uses the bare "AntiEntropy" atom
+      ae_name = Utils.camelize_and_concat([cache_name, "AntiEntropy"])
+
+      ae_pid = Process.whereis(ae_name)
+
+      assert ae_pid != nil
+      assert Process.alive?(ae_pid)
+
+      Supervisor.stop(pid)
     end
   end
 


### PR DESCRIPTION
Add optional bucket-based anti-entropy to detect and repair data drift between nodes after missed replication batches. Follows Riak's AAE design: 1024 fixed buckets with XOR fingerprints, random peer comparison, and repair through the inbox preserving "newer version wins" semantics.

Closes #12