### PR TITLE
fix(replicated): bound heap usage during bootstrap and anti-entropy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [Nebulex.Adapters.Replicated] Fixed excessive heap usage during bootstrap
+  and anti-entropy reconciliation that could OOM nodes with large caches on
+  deploy. The push-based bootstrap previously materialised the entire local
+  cache into a single list (and a single RPC payload) and emitted per-entry
+  primary-cache telemetry spans, both of which scaled with the cache size.
+  Bootstrap now streams entries chunk-by-chunk to the joining peer, and the
+  internal `ttl`/`put_new`/`put` calls used by bootstrap and anti-entropy
+  pass `telemetry: false` so they no longer emit per-entry spans or
+  increment primary-cache stats counters. The chunk size is configurable
+  via the new `:bootstrap_chunk_size` replication option (defaults to
+  `1_000`). Per-cycle visibility is preserved through the existing
+  `:bootstrap` and `:anti_entropy` span events.
+  [#15](https://github.com/elixir-nebulex/nebulex_distributed/issues/15).
+
 ## [v3.2.1](https://github.com/elixir-nebulex/nebulex_distributed/tree/v3.2.1) (2026-03-28)
 > [Full Changelog](https://github.com/elixir-nebulex/nebulex_distributed/compare/v3.2.0...v3.2.1)
 

--- a/lib/nebulex/adapters/replicated.ex
+++ b/lib/nebulex/adapters/replicated.ex
@@ -411,6 +411,61 @@ defmodule Nebulex.Adapters.Replicated do
         }
         ```
 
+  ### Bootstrap and anti-entropy: primary-cache events
+
+  The internal cache commands the bootstrap and anti-entropy paths issue
+  against the primary storage (entry streaming, per-entry `ttl` lookups on
+  the source, and `put_new`/`put` applications on the receiver) are emitted
+  with `telemetry: false`. This suppresses the Nebulex cache command events
+  on the primary storage, so the primary cache's stats counters
+  (`:hits`, `:writes`, etc.) are not incremented either.
+
+  This is intentional: bootstrap and anti-entropy are infrastructure
+  operations, not application traffic. Counting them per entry would inflate
+  hit-rate and write-rate dashboards by the cache's full size on every
+  redeploy or AE cycle, and would generate enough per-entry metadata to
+  put pressure on the BEAM heap on large caches.
+
+  Per-cycle visibility is preserved through the dedicated `:bootstrap` and
+  `:anti_entropy` span events documented above — `total` (entries pushed)
+  and `repaired` / `divergent_buckets` (entries reconciled) are reported in
+  the `:stop` metadata.
+
+  ### Asymmetry with normal replication
+
+  Normal replication of user-driven `put`/`delete` operations emits
+  telemetry on every replica that applies the write — bootstrap and
+  anti-entropy do not. Two telemetry prefixes are involved: the replicated
+  cache's own (`telemetry_prefix ++ [:command, …]`) and the primary
+  storage's (`telemetry_prefix ++ [:primary, :command, …]`). Which
+  `*, :stop` event fires for each operation:
+
+  | Operation                                 | Replicated | Primary |
+  | ----------------------------------------- | :--------: | :-----: |
+  | `Cache.put` on the entry node             |     ✓      |    ✓    |
+  | Same `put` applied on each replica        |     —      |    ✓    |
+  | Bootstrap push to a joining node          |     —      |    —    |
+  | Anti-entropy repair on a divergent peer   |     —      |    —    |
+
+  Concretely: a `Cache.put` on node A in a 3-node cluster fires the
+  replicated event once (on A) and the primary event three times (on A,
+  B, and C, as the same write lands locally and is applied on each replica
+  through the inbox). Bootstrapping a fourth node D with the same data
+  fires neither event for the bootstrapped entries.
+
+  Two consequences for dashboards:
+
+    * Aggregating the primary event across replicas over-counts user
+      writes by the replication fanout (one event per replica) and
+      under-counts anything bootstrap or anti-entropy populated. For
+      cluster-wide rates of user-driven activity, count the replicated
+      event instead — it fires exactly once per user call.
+    * After a bootstrap or anti-entropy repair, a replica's primary
+      `:writes` counter will be lower than its peers' even though the
+      primary contents converge. The primary prefix is still the right
+      signal for per-replica health (e.g., "is replica B applying
+      replication?") — just read it per-node, not summed across replicas.
+
   ## Anti-Entropy Reconciliation
 
   The replicated adapter supports optional anti-entropy reconciliation
@@ -605,6 +660,7 @@ defmodule Nebulex.Adapters.Replicated do
       replication_timeout: Keyword.fetch!(replication_opts, :timeout),
       replication_retries: Keyword.fetch!(replication_opts, :retries),
       replication_retry_delay: Keyword.fetch!(replication_opts, :retry_delay),
+      bootstrap_chunk_size: Keyword.fetch!(replication_opts, :bootstrap_chunk_size),
       anti_entropy_interval: Keyword.get(replication_opts, :anti_entropy_interval)
     }
 

--- a/lib/nebulex/adapters/replicated/anti_entropy.ex
+++ b/lib/nebulex/adapters/replicated/anti_entropy.ex
@@ -71,7 +71,7 @@ defmodule Nebulex.Adapters.Replicated.AntiEntropy do
     adapter_meta
     |> Replicated.with_dynamic_cache(:stream!, [
       [select: {:key, :value}],
-      [timeout: :infinity]
+      [timeout: :infinity, telemetry: false]
     ])
     |> Enum.reduce(:array.new(@buckets, default: 0), fn {key, value}, acc ->
       idx = :erlang.phash2(key, @buckets)
@@ -90,14 +90,14 @@ defmodule Nebulex.Adapters.Replicated.AntiEntropy do
     adapter_meta
     |> Replicated.with_dynamic_cache(:stream!, [
       [select: {:key, :value}],
-      [timeout: :infinity]
+      [timeout: :infinity, telemetry: false]
     ])
     |> Stream.filter(fn {key, _value} ->
       MapSet.member?(bucket_set, :erlang.phash2(key, @buckets))
     end)
     |> Stream.map(fn {key, value} ->
-      case Replicated.with_dynamic_cache(adapter_meta, :ttl, [key, []]) do
-        {:ok, ttl} -> {key, {:put, [key, value, [ttl: ttl]]}}
+      case Replicated.with_dynamic_cache(adapter_meta, :ttl, [key, [telemetry: false]]) do
+        {:ok, ttl} -> {key, {:put, [key, value, [ttl: ttl, telemetry: false]]}}
         _error -> nil
       end
     end)

--- a/lib/nebulex/adapters/replicated/options.ex
+++ b/lib/nebulex/adapters/replicated/options.ex
@@ -90,6 +90,18 @@ defmodule Nebulex.Adapters.Replicated.Options do
       Disabled by default (not present). Set to a positive integer
       to enable, e.g., `:timer.minutes(1)`.
       """
+    ],
+    bootstrap_chunk_size: [
+      type: :pos_integer,
+      required: false,
+      default: 1_000,
+      doc: """
+      Number of entries to push per RPC call when an existing node
+      bootstraps a newly joined peer. The local cache is streamed and
+      shipped chunk-by-chunk, bounding peak heap usage on both sender
+      and receiver regardless of the total cache size. Smaller values
+      reduce peak memory; larger values reduce RPC overhead.
+      """
     ]
   ]
 

--- a/lib/nebulex/adapters/replicated/replicator.ex
+++ b/lib/nebulex/adapters/replicated/replicator.ex
@@ -9,49 +9,50 @@ defmodule Nebulex.Adapters.Replicated.Replicator do
 
   @doc false
   def stream_entries(adapter_meta) do
+    # `telemetry: false` is set on every internal command so we don't emit a
+    # span per entry — those spans copy `adapter_meta`/`args`/`result` into
+    # event metadata and dominate GC pressure on large caches (see #15).
     adapter_meta
     |> Replicated.with_dynamic_cache(:stream!, [
       [select: {:key, :value}],
-      [timeout: :infinity]
+      [timeout: :infinity, telemetry: false]
     ])
     |> Stream.map(fn {key, value} ->
-      case Replicated.with_dynamic_cache(adapter_meta, :ttl, [key, []]) do
+      case Replicated.with_dynamic_cache(adapter_meta, :ttl, [key, [telemetry: false]]) do
         {:ok, ttl} ->
-          {key, {:put, [key, value, [ttl: ttl]]}}
+          {key, {:put, [key, value, [ttl: ttl, telemetry: false]]}}
 
         _error ->
           nil
       end
     end)
     |> Stream.reject(&is_nil/1)
-    |> Enum.to_list()
   end
 
   @doc false
   def push_entries(target_node, adapter_meta) do
-    case stream_entries(adapter_meta) do
-      [] ->
-        0
+    # Stream the local cache in chunks and ship one RPC per chunk so peak
+    # heap on both sender and receiver stays bounded regardless of total
+    # cache size. Each entry is converted from `:put` to `:put_new` so the
+    # bootstrap doesn't overwrite data the target already received via
+    # normal replication.
+    adapter_meta
+    |> stream_entries()
+    |> Stream.chunk_every(adapter_meta.bootstrap_chunk_size)
+    |> Enum.reduce(0, fn chunk, total ->
+      bootstrap_chunk =
+        Enum.map(chunk, fn {key, {:put, args}} -> {key, {:put_new, args}} end)
 
-      entries ->
-        # Convert :put to :put_new for bootstrap — only write if key doesn't
-        # exist on the target node, preserving any data it already received
-        # via normal replication.
-        bootstrap_entries =
-          Enum.map(entries, fn {key, {:put, args}} ->
-            {key, {:put_new, args}}
-          end)
+      RPC.call(
+        target_node,
+        __MODULE__,
+        :apply_bootstrap_entries,
+        [adapter_meta, bootstrap_chunk],
+        adapter_meta.replication_timeout
+      )
 
-        RPC.call(
-          target_node,
-          __MODULE__,
-          :apply_bootstrap_entries,
-          [adapter_meta, bootstrap_entries],
-          adapter_meta.replication_timeout
-        )
-
-        Enum.count(entries)
-    end
+      total + length(bootstrap_chunk)
+    end)
   end
 
   @doc false

--- a/test/nebulex/adapters/replicated_test.exs
+++ b/test/nebulex/adapters/replicated_test.exs
@@ -549,7 +549,9 @@ defmodule Nebulex.Adapters.ReplicatedCacheTest do
 
       # skip_key1 should be filtered out, skip_key2 should be present
       refute Map.has_key?(entries_map, :skip_key1)
-      assert entries_map[:skip_key2] == {:put, [:skip_key2, "value2", [ttl: :infinity]]}
+
+      assert entries_map[:skip_key2] ==
+               {:put, [:skip_key2, "value2", [ttl: :infinity, telemetry: false]]}
     end
 
     test "new node receives data from existing peers via inverted bootstrap", %{


### PR DESCRIPTION
Push-based bootstrap previously materialised the entire local cache into a single list, shipped it in one RPC payload, and emitted per-entry primary-cache telemetry spans — all of which scaled with the cache size and could OOM nodes with large caches on deploy.

- Bootstrap now streams entries chunk-by-chunk to the joining peer, with one RPC per chunk so peak heap stays bounded on both sender and receiver. Chunk size is configurable via the new replication `:bootstrap_chunk_size` option (defaults to `1_000`).
- Internal `:stream!`/`:ttl`/`:put_new`/`:put` calls used by bootstrap and anti-entropy now pass `telemetry: false`, so they no longer emit per-entry primary-cache spans or increment primary stats counters. Per-cycle visibility is preserved through the existing `:bootstrap` and `:anti_entropy` span events.
- Documented the resulting stats behaviour and the asymmetry with normal replication in the adapter moduledoc.

Closes #15.